### PR TITLE
Relax static asset routing path assertion

### DIFF
--- a/tests/test-static-asset-routing.mjs
+++ b/tests/test-static-asset-routing.mjs
@@ -118,7 +118,7 @@ async function main() {
   try {
     const page = await request(port, '/');
     assert.equal(page.status, 200, 'chat page should render');
-    assert.match(page.text, /<script src="\/chat\/icons\.js(?:\?v=[^"]+)?"/);
+    assert.match(page.text, /<script src="\/?chat\/icons\.js(?:\?v=[^"]+)?"/);
 
     const probe = await request(port, `/chat/${probeName}`);
     assert.equal(probe.status, 200, 'new static asset should load without router filename changes');


### PR DESCRIPTION
## Summary
- allow `test-static-asset-routing` to accept either `chat/icons.js` or `/chat/icons.js`
- keep the existing chat HTML contract unchanged while still verifying the script tag is present

## Validation
- `npm run test:restart-gate`
- `npm test`

## Context
The failed CI run for `ea308dffc1d42b5b7b02819b6e014607c86f8706` was caused by a brittle assertion in `tests/test-static-asset-routing.mjs`. The rendered chat page still uses a `<base href="/">`, and the broader frontend suite already treats the split asset tags as relative paths.