### PR TITLE
Add Feishu topic fork routing and spawn arg sanitization

### DIFF
--- a/chat/adapters/claude.mjs
+++ b/chat/adapters/claude.mjs
@@ -2,6 +2,7 @@ import {
   messageEvent, toolUseEvent, toolResultEvent,
   reasoningEvent, statusEvent, usageEvent,
 } from '../normalizer.mjs';
+import { sanitizeSpawnArgs } from '../spawn-arg-sanitizer.mjs';
 
 /**
  * Claude Code adapter.
@@ -194,5 +195,5 @@ export function buildClaudeArgs(prompt, options = {}) {
   }
   // effort === 'none' → no --effort flag → thinking disabled
 
-  return args;
+  return sanitizeSpawnArgs(args);
 }

--- a/chat/adapters/codex.mjs
+++ b/chat/adapters/codex.mjs
@@ -7,6 +7,7 @@ import {
   INSTANCE_LOCAL_ACCESS_BOUNDARY_ENFORCED,
   IS_GUEST_INSTANCE,
 } from '../../lib/config.mjs';
+import { sanitizeSpawnArgs } from '../spawn-arg-sanitizer.mjs';
 
 export { DEFAULT_CODEX_DEVELOPER_INSTRUCTIONS } from '../runtime-policy.mjs';
 
@@ -273,5 +274,5 @@ export function buildCodexArgs(prompt, options = {}) {
     args.push(effectivePrompt);
   }
 
-  return args;
+  return sanitizeSpawnArgs(args);
 }

--- a/chat/router-control-routes.mjs
+++ b/chat/router-control-routes.mjs
@@ -831,6 +831,14 @@ export async function handleControlRoutes({
         writeJson(res, 403, { error: 'Access denied' });
         return true;
       }
+      let payload = {};
+      try {
+        const body = await readBody(req, 10240);
+        payload = body ? JSON.parse(body) : {};
+      } catch {
+        writeJson(res, 400, { error: 'Invalid request body' });
+        return true;
+      }
       const source = await getSessionForClient(sessionId);
       if (!source) {
         writeJson(res, 404, { error: 'Session not found' });
@@ -840,11 +848,7 @@ export async function handleControlRoutes({
         writeJson(res, 409, { error: 'Visitor sessions cannot be forked' });
         return true;
       }
-      if (source.activity?.run?.state === 'running') {
-        writeJson(res, 409, { error: 'Session is running' });
-        return true;
-      }
-      const session = await forkSession(sessionId);
+      const session = await forkSession(sessionId, payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {});
       if (!session) {
         writeJson(res, 409, { error: 'Unable to fork session' });
         return true;

--- a/chat/session-manager.mjs
+++ b/chat/session-manager.mjs
@@ -88,6 +88,7 @@ import {
   resolveSessionRunActivity,
 } from './session-activity.mjs';
 import {
+  findSessionByExternalTriggerId,
   findSessionMeta,
   findSessionMetaCached,
   loadSessionsMeta,
@@ -4084,7 +4085,13 @@ export async function getHistory(sessionId) {
   return loadHistory(sessionId);
 }
 
-export async function forkSession(sessionId) {
+export async function forkSession(sessionId, options = {}) {
+  const requestedExternalTriggerId = typeof options.externalTriggerId === 'string' ? options.externalTriggerId.trim() : '';
+  if (requestedExternalTriggerId) {
+    const existing = await findSessionByExternalTriggerId(requestedExternalTriggerId);
+    if (existing) return await getSession(existing.id) || existing;
+  }
+
   const source = await getSession(sessionId);
   if (!source) return null;
   if (source.visitorId) return null;
@@ -4097,17 +4104,20 @@ export async function forkSession(sessionId) {
   ]);
   const forkContext = await getOrPrepareForkContext(sessionId, snapshot, contextHead);
 
-  const child = await createSession(source.folder, source.tool, buildForkSessionName(source), {
-    group: source.group || '',
-    description: source.description || '',
-    sourceId: source.sourceId || '',
-    sourceName: source.sourceName || '',
-    templateId: source.templateId || '',
-    templateName: source.templateName || '',
-    systemPrompt: source.systemPrompt || '',
+  const hasSourceContextOverride = Object.prototype.hasOwnProperty.call(options, 'sourceContext');
+  const child = await createSession(source.folder, source.tool, typeof options.name === 'string' && options.name.trim() ? options.name.trim() : buildForkSessionName(source), {
+    group: typeof options.group === 'string' && options.group.trim() ? options.group : (source.group || ''),
+    description: typeof options.description === 'string' && options.description.trim() ? options.description : (source.description || ''),
+    sourceId: typeof options.sourceId === 'string' && options.sourceId.trim() ? options.sourceId : (source.sourceId || ''),
+    sourceName: typeof options.sourceName === 'string' && options.sourceName.trim() ? options.sourceName : (source.sourceName || ''),
+    templateId: typeof options.templateId === 'string' && options.templateId.trim() ? options.templateId : (source.templateId || ''),
+    templateName: typeof options.templateName === 'string' && options.templateName.trim() ? options.templateName : (source.templateName || ''),
+    systemPrompt: Object.prototype.hasOwnProperty.call(options, 'systemPrompt') && typeof options.systemPrompt === 'string' ? options.systemPrompt : (source.systemPrompt || ''),
     activeAgreements: source.activeAgreements || [],
     userId: source.userId || '',
     userName: source.userName || '',
+    externalTriggerId: requestedExternalTriggerId,
+    ...(hasSourceContextOverride ? { sourceContext: options.sourceContext } : {}),
     forkedFromSessionId: source.id,
     forkedFromSeq: source.latestSeq || 0,
     rootSessionId: source.rootSessionId || source.id,

--- a/chat/spawn-arg-sanitizer.mjs
+++ b/chat/spawn-arg-sanitizer.mjs
@@ -1,0 +1,10 @@
+const NUL_BYTE_RE = /\u0000/g;
+
+export function sanitizeSpawnArg(value) {
+  if (typeof value !== 'string') return value;
+  return value.includes('\u0000') ? value.replace(NUL_BYTE_RE, '') : value;
+}
+
+export function sanitizeSpawnArgs(args) {
+  return args.map((arg) => sanitizeSpawnArg(arg));
+}

--- a/lib/connector-message-index.mjs
+++ b/lib/connector-message-index.mjs
@@ -1,0 +1,91 @@
+import { readJson, writeJsonAtomic } from '../chat/fs-utils.mjs';
+
+function trimString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function normalizeKeyPart(value) {
+  return trimString(value).replace(/[^a-zA-Z0-9_.:-]+/g, '_').slice(0, 160);
+}
+
+export function connectorMessageIndexKey(record = {}) {
+  const connector = normalizeKeyPart(record.connector);
+  const messageId = normalizeKeyPart(record.messageId);
+  if (!connector || !messageId) return '';
+  const accountId = normalizeKeyPart(record.accountId || record.tenantKey || '');
+  return [connector, accountId, messageId].filter(Boolean).join(':');
+}
+
+export function normalizeConnectorMessageIndexRecord(record = {}) {
+  const connector = trimString(record.connector);
+  const messageId = trimString(record.messageId);
+  const sessionId = trimString(record.sessionId);
+  if (!connector || !messageId || !sessionId) return null;
+  return {
+    connector,
+    messageId,
+    sessionId,
+    ...(trimString(record.accountId || record.tenantKey) ? { accountId: trimString(record.accountId || record.tenantKey) } : {}),
+    ...(trimString(record.chatId) ? { chatId: trimString(record.chatId) } : {}),
+    ...(trimString(record.conversationId || record.topicId) ? { conversationId: trimString(record.conversationId || record.topicId) } : {}),
+    ...(trimString(record.externalTriggerId) ? { externalTriggerId: trimString(record.externalTriggerId) } : {}),
+    ...(trimString(record.sourceMessageId) ? { sourceMessageId: trimString(record.sourceMessageId) } : {}),
+    ...(trimString(record.direction) ? { direction: trimString(record.direction) } : {}),
+    ...(Number.isInteger(record.eventSeq) ? { eventSeq: record.eventSeq } : {}),
+    createdAt: trimString(record.createdAt) || nowIso(),
+    updatedAt: trimString(record.updatedAt) || nowIso(),
+  };
+}
+
+export async function loadConnectorMessageIndex(pathname) {
+  const document = await readJson(pathname, { records: {} });
+  return document && typeof document === 'object' && !Array.isArray(document)
+    ? { records: document.records && typeof document.records === 'object' && !Array.isArray(document.records) ? document.records : {} }
+    : { records: {} };
+}
+
+export async function upsertConnectorMessageIndexRecord(pathname, record) {
+  const normalized = normalizeConnectorMessageIndexRecord(record);
+  if (!normalized) return null;
+  const key = connectorMessageIndexKey(normalized);
+  if (!key) return null;
+  const document = await loadConnectorMessageIndex(pathname);
+  const existing = document.records[key] || {};
+  const next = {
+    ...existing,
+    ...normalized,
+    createdAt: trimString(existing.createdAt) || normalized.createdAt,
+    updatedAt: nowIso(),
+  };
+  document.records[key] = next;
+  await writeJsonAtomic(pathname, document);
+  return next;
+}
+
+export async function findConnectorMessageIndexRecord(pathname, query = {}) {
+  const connector = trimString(query.connector);
+  const messageId = trimString(query.messageId);
+  if (!connector || !messageId) return null;
+  const accountId = trimString(query.accountId || query.tenantKey || '');
+  const document = await loadConnectorMessageIndex(pathname);
+  const directKey = connectorMessageIndexKey({ connector, accountId, messageId });
+  const direct = directKey ? document.records[directKey] : null;
+  const candidates = direct
+    ? [direct]
+    : Object.values(document.records).filter((record) => (
+      trimString(record?.connector) === connector
+      && trimString(record?.messageId) === messageId
+    ));
+  const chatId = trimString(query.chatId);
+  const conversationId = trimString(query.conversationId || query.topicId || '');
+  return candidates.find((record) => {
+    if (accountId && trimString(record.accountId) && trimString(record.accountId) !== accountId) return false;
+    if (chatId && trimString(record.chatId) && trimString(record.chatId) !== chatId) return false;
+    if (conversationId && trimString(record.conversationId) && trimString(record.conversationId) !== conversationId) return false;
+    return true;
+  }) || null;
+}

--- a/lib/connector-turn-flow.mjs
+++ b/lib/connector-turn-flow.mjs
@@ -9,7 +9,21 @@ function trimString(value) {
   return typeof value === 'string' ? value.trim() : '';
 }
 
-export async function createConnectorSession(requester, payload) {
+export async function createConnectorSession(requester, payload, options = {}) {
+  const forkFromSessionId = trimString(options.forkFromSessionId);
+  if (forkFromSessionId) {
+    const forkResult = await requester(`/api/sessions/${encodeURIComponent(forkFromSessionId)}/fork`, {
+      method: 'POST',
+      body: payload,
+    });
+    if (forkResult.response?.ok && forkResult.json?.session?.id) {
+      return forkResult.json.session;
+    }
+    if (options.fallbackCreateOnForkFailure !== true) {
+      throw new Error(forkResult.json?.error || forkResult.text || `Failed to fork connector session (${forkResult.response?.status || 'unknown'})`);
+    }
+  }
+
   const result = await requester('/api/sessions', {
     method: 'POST',
     body: payload,

--- a/scripts/feishu-connector.mjs
+++ b/scripts/feishu-connector.mjs
@@ -33,6 +33,10 @@ import {
   submitConnectorMessage,
   waitForConnectorPublication,
 } from '../lib/connector-turn-flow.mjs';
+import {
+  findConnectorMessageIndexRecord,
+  upsertConnectorMessageIndexRecord,
+} from '../lib/connector-message-index.mjs';
 
 const DEFAULT_CONFIG_PATH = process.env.REMOTELAB_FEISHU_CONFIG_PATH
   ? resolve(process.env.REMOTELAB_FEISHU_CONFIG_PATH)
@@ -59,6 +63,7 @@ const DEFAULT_SESSION_SYSTEM_PROMPT = [
 ].join('\n');
 const RUN_POLL_INTERVAL_MS = 1500;
 const RUN_POLL_TIMEOUT_MS = 0;
+const PROCESS_KEEPALIVE_INTERVAL_MS = 60_000;
 const MAX_FEISHU_TEXT_LENGTH = 5000;
 const MAX_INBOUND_LOG_PREVIEW_LENGTH = 240;
 const MAX_FEISHU_RESOURCE_BYTES = 100 * 1024 * 1024;
@@ -1195,6 +1200,18 @@ function buildExternalTriggerId(summary) {
   return `feishu:${sanitizeIdPart(summary?.chatType || 'chat')}:${chatId}`;
 }
 
+function buildFeishuQueueKey(summary) {
+  const chatId = trimString(summary?.chatId);
+  const topicId = buildFeishuTopicId(summary);
+  if (topicId) {
+    return `feishu:topic:${sanitizeIdPart(chatId || 'unknown_chat')}:${sanitizeIdPart(topicId)}`;
+  }
+  if (chatId) {
+    return `feishu:${sanitizeIdPart(summary?.chatType || 'chat')}:${sanitizeIdPart(chatId)}`;
+  }
+  return `feishu:message:${sanitizeIdPart(summary?.messageId || 'unknown_message')}`;
+}
+
 function buildRequestId(summary) {
   return `feishu:${sanitizeIdPart(summary.messageId || `${Date.now()}`)}`;
 }
@@ -1683,7 +1700,7 @@ function createRuntimeContext(config, storagePaths, accessState) {
 }
 
 function enqueueByChat(runtime, summary, worker) {
-  const key = summary.chatId || summary.messageId || 'unknown_chat';
+  const key = buildFeishuQueueKey(summary);
   const previous = runtime.chatQueues.get(key) || Promise.resolve();
   const next = previous
     .catch(() => {})
@@ -1907,6 +1924,202 @@ async function waitForQueuedRequestRun(runtime, sessionId, match = {}) {
   throw new Error(`queued request timed out after ${RUN_POLL_TIMEOUT_MS}ms`);
 }
 
+function buildFeishuMessageIndexRecord(summary, sessionId) {
+  const messageId = trimString(summary?.messageId);
+  const normalizedSessionId = trimString(sessionId);
+  if (!messageId || !normalizedSessionId) return null;
+  return {
+    connector: 'feishu',
+    accountId: trimString(summary?.tenantKey || summary?.sender?.tenantKey),
+    messageId,
+    sessionId: normalizedSessionId,
+    chatId: trimString(summary?.chatId),
+    conversationId: buildFeishuTopicId(summary) || buildExternalTriggerId(summary),
+    externalTriggerId: buildExternalTriggerId(summary),
+    direction: 'inbound',
+  };
+}
+
+function buildFeishuOutboundMessageIndexRecord(summary, sessionId, outboundMessageId) {
+  const messageId = trimString(outboundMessageId);
+  const normalizedSessionId = trimString(sessionId);
+  if (!messageId || !normalizedSessionId) return null;
+  return {
+    connector: 'feishu',
+    accountId: trimString(summary?.tenantKey || summary?.sender?.tenantKey),
+    messageId,
+    sessionId: normalizedSessionId,
+    chatId: trimString(summary?.chatId),
+    conversationId: buildFeishuTopicId(summary) || buildExternalTriggerId(summary),
+    externalTriggerId: buildExternalTriggerId(summary),
+    sourceMessageId: trimString(summary?.messageId),
+    direction: 'outbound',
+  };
+}
+
+async function recordFeishuMessageSession(runtime, summary, sessionId) {
+  const pathname = trimString(runtime?.storagePaths?.messageIndexPath);
+  if (!pathname) return null;
+  const record = buildFeishuMessageIndexRecord(summary, sessionId);
+  if (!record) return null;
+  return await upsertConnectorMessageIndexRecord(pathname, record);
+}
+
+async function recordFeishuOutboundMessageSession(runtime, summary, sessionId, outboundMessageId) {
+  const pathname = trimString(runtime?.storagePaths?.messageIndexPath);
+  if (!pathname) return null;
+  const record = buildFeishuOutboundMessageIndexRecord(summary, sessionId, outboundMessageId);
+  if (!record) return null;
+  return await upsertConnectorMessageIndexRecord(pathname, record);
+}
+
+async function loadRemoteLabSessionWithRequester(requester, sessionId) {
+  const result = await requester(`/api/sessions/${encodeURIComponent(sessionId)}`);
+  if (!result.response?.ok || !result.json?.session) return null;
+  return result.json.session;
+}
+
+async function loadRemoteLabEventsWithRequester(requester, sessionId) {
+  const result = await requester(`/api/sessions/${encodeURIComponent(sessionId)}/events?filter=all`);
+  if (!result.response?.ok || !Array.isArray(result.json?.events)) return [];
+  return result.json.events;
+}
+
+function sessionMatchesFeishuChat(session, summary) {
+  if (trimString(session?.sourceId) !== 'feishu') return false;
+  const chatId = trimString(summary?.chatId);
+  if (!chatId) return true;
+  const contextChatId = trimString(session?.sourceContext?.chatId);
+  return !contextChatId || contextChatId === chatId;
+}
+
+async function verifyFeishuSessionReferencesMessage(requester, sessionId, summary, messageId) {
+  const session = await loadRemoteLabSessionWithRequester(requester, sessionId);
+  if (!session || !sessionMatchesFeishuChat(session, summary)) return false;
+  const events = await loadRemoteLabEventsWithRequester(requester, sessionId);
+  return events.some((event) => sourceContextReferencesRequest(event?.sourceContext, '', messageId));
+}
+
+async function verifyFeishuIndexedSessionRecord(requester, record, summary, messageId) {
+  const sessionId = trimString(record?.sessionId);
+  if (!sessionId) return false;
+  const verificationMessageId = trimString(record?.sourceMessageId) || trimString(messageId);
+  if (!verificationMessageId) return false;
+  return await verifyFeishuSessionReferencesMessage(requester, sessionId, summary, verificationMessageId);
+}
+
+function feishuSessionTriggerMatchesChat(session, summary) {
+  const chatId = trimString(summary?.chatId);
+  if (!chatId) return true;
+  const triggerId = trimString(session?.externalTriggerId);
+  return triggerId === `feishu:${sanitizeIdPart(summary?.chatType || 'chat')}:${sanitizeIdPart(chatId)}`
+    || triggerId.startsWith(`feishu:topic:${sanitizeIdPart(chatId)}:`);
+}
+
+async function findFeishuParentSessionFromFacts(requester, summary, messageId) {
+  const result = await requester('/api/sessions?sourceId=feishu');
+  if (!result.response?.ok || !Array.isArray(result.json?.sessions)) return '';
+  const candidates = result.json.sessions.filter((session) => (
+    trimString(session?.id)
+    && trimString(session?.sourceId) === 'feishu'
+    && session?.archived !== true
+    && feishuSessionTriggerMatchesChat(session, summary)
+  ));
+  for (const candidate of candidates) {
+    if (await verifyFeishuSessionReferencesMessage(requester, candidate.id, summary, messageId)) {
+      return candidate.id;
+    }
+  }
+  return '';
+}
+
+async function findFeishuParentSessionFromHandledMessages(runtime, requester, summary, messageId) {
+  const handledPath = trimString(runtime?.storagePaths?.handledMessagesPath);
+  if (!handledPath) return null;
+  const state = await loadHandledMessages(handledPath);
+  const messages = state?.messages && typeof state.messages === 'object' && !Array.isArray(state.messages)
+    ? state.messages
+    : {};
+  const chatId = trimString(summary?.chatId);
+  for (const [sourceMessageId, metadata] of Object.entries(messages)) {
+    if (trimString(metadata?.responseMessageId) !== messageId) continue;
+    if (chatId && trimString(metadata?.chatId) && trimString(metadata.chatId) !== chatId) continue;
+    const sessionId = trimString(metadata?.sessionId);
+    const verifiedSourceMessageId = trimString(sourceMessageId);
+    if (!sessionId || !verifiedSourceMessageId) continue;
+    if (await verifyFeishuSessionReferencesMessage(requester, sessionId, summary, verifiedSourceMessageId)) {
+      return {
+        sessionId,
+        sourceMessageId: verifiedSourceMessageId,
+      };
+    }
+  }
+  return null;
+}
+
+function collectFeishuTopicParentMessageCandidates(summary) {
+  const currentMessageId = trimString(summary?.messageId);
+  const seen = new Set();
+  const candidates = [];
+  for (const value of [summary?.rootId, summary?.parentId, summary?.threadId]) {
+    const messageId = trimString(value);
+    if (!messageId || messageId === currentMessageId || seen.has(messageId)) continue;
+    seen.add(messageId);
+    candidates.push(messageId);
+  }
+  return candidates;
+}
+
+async function resolveFeishuTopicForkParentSessionId(runtime, requester, summary) {
+  if (!buildFeishuTopicId(summary)) return '';
+  const parentMessageIds = collectFeishuTopicParentMessageCandidates(summary);
+  if (parentMessageIds.length === 0) return '';
+  const indexPath = trimString(runtime?.storagePaths?.messageIndexPath);
+  for (const parentMessageId of parentMessageIds) {
+    if (indexPath) {
+      const indexed = await findConnectorMessageIndexRecord(indexPath, {
+        connector: 'feishu',
+        accountId: trimString(summary?.tenantKey || summary?.sender?.tenantKey),
+        messageId: parentMessageId,
+        chatId: trimString(summary?.chatId),
+      });
+      const sessionId = trimString(indexed?.sessionId);
+      if (sessionId && await verifyFeishuIndexedSessionRecord(requester, indexed, summary, parentMessageId)) {
+        return sessionId;
+      }
+    }
+    const factSessionId = await findFeishuParentSessionFromFacts(requester, summary, parentMessageId);
+    if (factSessionId && indexPath) {
+      await upsertConnectorMessageIndexRecord(indexPath, {
+        connector: 'feishu',
+        accountId: trimString(summary?.tenantKey || summary?.sender?.tenantKey),
+        messageId: parentMessageId,
+        sessionId: factSessionId,
+        chatId: trimString(summary?.chatId),
+        externalTriggerId: buildExternalTriggerId({ ...summary, messageId: parentMessageId, threadId: '', rootId: '', parentId: '' }),
+        direction: 'inbound',
+      });
+    }
+    if (factSessionId) return factSessionId;
+    const handledMatch = await findFeishuParentSessionFromHandledMessages(runtime, requester, summary, parentMessageId);
+    if (handledMatch?.sessionId && indexPath) {
+      await upsertConnectorMessageIndexRecord(indexPath, {
+        connector: 'feishu',
+        accountId: trimString(summary?.tenantKey || summary?.sender?.tenantKey),
+        messageId: parentMessageId,
+        sessionId: handledMatch.sessionId,
+        chatId: trimString(summary?.chatId),
+        externalTriggerId: buildExternalTriggerId({ ...summary, messageId: parentMessageId, threadId: '', rootId: '', parentId: '' }),
+        sourceMessageId: handledMatch.sourceMessageId,
+        direction: 'outbound',
+      });
+    }
+    if (handledMatch?.sessionId) return handledMatch.sessionId;
+  }
+  console.warn(`[feishu-connector] no verified topic fork parent session found for ${summary.messageId}; candidates=${parentMessageIds.join(',')}`);
+  return '';
+}
+
 async function createOrReuseSession(runtime, summary, runtimeSelection) {
   const sourceName = runtime.config.region === 'lark-global' ? 'Lark' : 'Feishu';
   const payload = {
@@ -2030,7 +2243,7 @@ async function generateRemoteLabReply(runtime, summary) {
     ? { ...effectiveSummary, attachmentDownloadFailures: attachmentResolution.failures }
     : effectiveSummary;
   const requester = (path, options = {}) => requestRemoteLab(runtime, path, options);
-  const session = await createConnectorSession(requester, {
+  const sessionPayload = {
     folder: runtime.config.sessionFolder,
     tool: runtimeSelection.tool,
     name: buildSessionName(effectiveSummary),
@@ -2041,6 +2254,11 @@ async function generateRemoteLabReply(runtime, summary) {
     systemPrompt: runtime.config.systemPrompt,
     externalTriggerId: buildExternalTriggerId(effectiveSummary),
     sourceContext: buildSessionSourceContext(effectiveSummary),
+  };
+  const forkFromSessionId = await resolveFeishuTopicForkParentSessionId(runtime, requester, effectiveSummary);
+  const session = await createConnectorSession(requester, sessionPayload, {
+    forkFromSessionId,
+    fallbackCreateOnForkFailure: true,
   });
   const submission = await submitConnectorMessage(requester, session.id, {
     requestId: buildRequestId(effectiveSummary),
@@ -2541,6 +2759,11 @@ async function handleMessage(runtime, summary, sourceLabel, helpers = {}) {
     }
 
     const generated = await generateReply(runtime, summary);
+    try {
+      await recordFeishuMessageSession(runtime, summary, generated.sessionId);
+    } catch (indexError) {
+      console.warn(`[feishu-connector] failed to update message index for ${summary.messageId}: ${indexError?.message || indexError}`);
+    }
     const replyText = normalizeReplyText(generated.replyText);
     const finalReply = decideConnectorUserVisibleReply({
       replyText,
@@ -2567,6 +2790,11 @@ async function handleMessage(runtime, summary, sourceLabel, helpers = {}) {
       kind: finalReply.action === 'send_confirmation' ? 'summary' : 'content',
       text: finalReply.text,
     }, sendText);
+    try {
+      await recordFeishuOutboundMessageSession(runtime, summary, generated.sessionId, reply.message_id);
+    } catch (indexError) {
+      console.warn(`[feishu-connector] failed to update outbound message index for ${reply.message_id || summary.messageId}: ${indexError?.message || indexError}`);
+    }
     await markHandled(runtime.storagePaths.handledMessagesPath, summary.messageId, {
       status: finalReply.status,
       sourceLabel,
@@ -2622,6 +2850,8 @@ export {
   buildApprovedChatReply,
   buildChatAccessStatusReply,
   buildExternalTriggerId,
+  buildFeishuMessageIndexRecord,
+  buildFeishuQueueKey,
   buildFeishuTopicId,
   buildMessageSourceContext,
   buildRemoteLabMessage,
@@ -2649,6 +2879,7 @@ export {
   queueAccessStateFlush,
   releaseConnectorPidLock,
   removeProcessingReaction,
+  resolveFeishuTopicForkParentSessionId,
   resolveFeishuMessageAttachments,
   sendFeishuText,
   snapshotAccessState,
@@ -2676,6 +2907,7 @@ async function main() {
     eventsLogPath: join(config.storageDir, 'events.jsonl'),
     knownSendersPath: join(config.storageDir, 'known-senders.json'),
     handledMessagesPath: join(config.storageDir, 'handled-messages.json'),
+    messageIndexPath: join(config.storageDir, 'connector-message-index.json'),
   };
   const runtime = createRuntimeContext(config, storagePaths, accessState);
   const wsClient = new Lark.WSClient({
@@ -2738,6 +2970,7 @@ async function main() {
   console.log(`[feishu-connector] event log: ${storagePaths.eventsLogPath}`);
   console.log(`[feishu-connector] known senders: ${storagePaths.knownSendersPath}`);
   console.log(`[feishu-connector] handled messages: ${storagePaths.handledMessagesPath}`);
+  console.log(`[feishu-connector] message index: ${storagePaths.messageIndexPath}`);
   console.log(`[feishu-connector] RemoteLab base URL: ${config.chatBaseUrl}`);
   console.log(`[feishu-connector] session folder: ${config.sessionFolder}`);
   console.log(
@@ -2769,6 +3002,7 @@ async function main() {
     return;
   }
 
+  setInterval(() => {}, PROCESS_KEEPALIVE_INTERVAL_MS);
   await new Promise(() => {});
 }
 

--- a/tests/test-codex-prompt-sanitization.mjs
+++ b/tests/test-codex-prompt-sanitization.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import assert from 'assert/strict';
+
+import { buildCodexArgs } from '../chat/adapters/codex.mjs';
+
+const promptWithNul = 'history before\u0000history after';
+
+const freshArgs = buildCodexArgs(promptWithNul);
+assert.equal(
+  freshArgs.some((arg) => typeof arg === 'string' && arg.includes('\u0000')),
+  false,
+  'codex argv must not contain NUL bytes for fresh runs',
+);
+assert.match(
+  freshArgs[freshArgs.length - 1],
+  /history before/,
+  'sanitized prompt should preserve surrounding text before NUL',
+);
+assert.match(
+  freshArgs[freshArgs.length - 1],
+  /history after/,
+  'sanitized prompt should preserve surrounding text after NUL',
+);
+
+const resumeArgs = buildCodexArgs(promptWithNul, { threadId: 'codex-thread-1' });
+assert.equal(
+  resumeArgs.some((arg) => typeof arg === 'string' && arg.includes('\u0000')),
+  false,
+  'codex argv must not contain NUL bytes for resume runs',
+);
+
+console.log('test-codex-prompt-sanitization: ok');

--- a/tests/test-feishu-connector.mjs
+++ b/tests/test-feishu-connector.mjs
@@ -14,6 +14,10 @@ process.env.HOME = tempHome;
 const { selectAssistantReplyEvent } = await import(pathToFileURL(join(repoRoot, 'lib', 'reply-selection.mjs')).href);
 const { waitForReplyPublication } = await import(pathToFileURL(join(repoRoot, 'lib', 'reply-publication-client.mjs')).href);
 const { saveUiRuntimeSelection } = await import(pathToFileURL(join(repoRoot, 'lib', 'runtime-selection.mjs')).href);
+const {
+  findConnectorMessageIndexRecord,
+  upsertConnectorMessageIndexRecord,
+} = await import(pathToFileURL(join(repoRoot, 'lib', 'connector-message-index.mjs')).href);
 
 const {
   DEFAULT_SESSION_SYSTEM_PROMPT,
@@ -37,8 +41,11 @@ const {
   resolveFeishuMessageAttachments,
   buildFeishuPostContent,
   buildExternalTriggerId,
+  buildFeishuMessageIndexRecord,
+  buildFeishuQueueKey,
   buildMessageSourceContext,
   buildSessionSourceContext,
+  resolveFeishuTopicForkParentSessionId,
   sendFeishuText,
   summarizeChatMemberUserAddedEvent,
   summarizeEvent,
@@ -48,6 +55,7 @@ const runtime = {
   processingMessageIds: new Set(),
   storagePaths: {
     handledMessagesPath: '/tmp/remotelab-feishu-connector-test-handled.json',
+    messageIndexPath: join(tempHome, 'connector-message-index.json'),
   },
 };
 
@@ -68,6 +76,47 @@ const noTimeoutPublication = await waitForReplyPublication(async () => {
 });
 assert.equal(noTimeoutPublication.state, 'ready');
 assert.equal(publicationPolls, 3, 'timeoutMs=0 should wait until a terminal reply publication');
+
+assert.equal(
+  buildFeishuQueueKey({ chatType: 'group', chatId: 'chat_topic_test', threadId: 'thread_a' }),
+  'feishu:topic:chat_topic_test:thread_a',
+  'topic messages should queue by topic, not only by group chat',
+);
+assert.equal(
+  buildFeishuQueueKey({ chatType: 'group', chatId: 'chat_topic_test', rootId: 'root_a' }),
+  'feishu:topic:chat_topic_test:root_a',
+  'root-id topic messages should queue by topic root',
+);
+assert.notEqual(
+  buildFeishuQueueKey({ chatType: 'group', chatId: 'chat_topic_test', threadId: 'thread_a' }),
+  buildFeishuQueueKey({ chatType: 'group', chatId: 'chat_topic_test', threadId: 'thread_b' }),
+  'different topics in the same group should use different queue keys',
+);
+assert.equal(
+  buildFeishuQueueKey({ chatType: 'group', chatId: 'chat_topic_test', messageId: 'msg_a' }),
+  buildFeishuQueueKey({ chatType: 'group', chatId: 'chat_topic_test', messageId: 'msg_b' }),
+  'non-topic group messages should still serialize by group chat',
+);
+assert.deepEqual(
+  buildFeishuMessageIndexRecord({
+    tenantKey: 'tenant_topic_test',
+    chatType: 'group',
+    chatId: 'chat_topic_test',
+    messageId: 'msg_topic_root_index',
+    threadId: 'thread_topic_index',
+  }, 'sess_topic_index'),
+  {
+    connector: 'feishu',
+    accountId: 'tenant_topic_test',
+    messageId: 'msg_topic_root_index',
+    sessionId: 'sess_topic_index',
+    chatId: 'chat_topic_test',
+    conversationId: 'thread_topic_index',
+    externalTriggerId: 'feishu:topic:chat_topic_test:thread_topic_index',
+    direction: 'inbound',
+  },
+  'Feishu message index records should keep connector, message, session, and conversation identity',
+);
 
 const summary = {
   messageId: 'msg_test_1',
@@ -169,6 +218,14 @@ assert.equal(handled[0].messageId, 'msg_test_confirmation_plain_1');
 assert.equal(handled[0].metadata.status, 'confirmation_sent');
 assert.equal(handled[0].metadata.reason, 'empty_assistant_reply');
 assert.equal(handled[0].metadata.responseMessageId, 'out_confirmation_plain_test_1');
+const outboundConfirmationIndexRecord = await findConnectorMessageIndexRecord(runtime.storagePaths.messageIndexPath, {
+  connector: 'feishu',
+  messageId: 'out_confirmation_plain_test_1',
+  chatId: 'chat_test_1',
+});
+assert.equal(outboundConfirmationIndexRecord?.sessionId, 'session_confirmation_plain_test_1');
+assert.equal(outboundConfirmationIndexRecord?.sourceMessageId, 'msg_test_confirmation_plain_1');
+assert.equal(outboundConfirmationIndexRecord?.direction, 'outbound');
 
 const connectorLockDir = join(tempHome, 'connector-lock');
 const claimedLock = await claimConnectorPidLock(connectorLockDir, 54321);
@@ -1226,6 +1283,265 @@ try {
 } finally {
   await new Promise((resolve) => server.close(resolve));
   await rm(tempHome, { recursive: true, force: true });
+}
+
+const topicForkTempDir = await mkdtemp(join(tmpdir(), 'remotelab-feishu-topic-fork-'));
+const topicForkIndexPath = join(topicForkTempDir, 'connector-message-index.json');
+await upsertConnectorMessageIndexRecord(topicForkIndexPath, {
+  connector: 'feishu',
+  accountId: 'tenant_topic_fork',
+  messageId: 'msg_topic_parent_1',
+  sessionId: 'sess_parent_topic_fork',
+  chatId: 'chat_topic_fork_1',
+  externalTriggerId: 'feishu:group:chat_topic_fork_1',
+});
+await upsertConnectorMessageIndexRecord(topicForkIndexPath, {
+  connector: 'feishu',
+  accountId: 'tenant_topic_fork',
+  messageId: 'bot_reply_topic_parent_1',
+  sessionId: 'sess_parent_topic_fork',
+  chatId: 'chat_topic_fork_1',
+  externalTriggerId: 'feishu:group:chat_topic_fork_1',
+  sourceMessageId: 'msg_topic_parent_1',
+  direction: 'outbound',
+});
+
+let topicForkPayload = null;
+let topicForkSubmittedPayload = null;
+let topicFreshCreateCalled = false;
+const topicForkServer = http.createServer(async (req, res) => {
+  let body = '';
+  req.on('data', (chunk) => {
+    body += chunk.toString();
+  });
+  await new Promise((resolve) => req.on('end', resolve));
+
+  if (req.method === 'GET' && req.url === '/api/sessions?sourceId=feishu') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      sessions: [{
+        id: 'sess_parent_topic_fork',
+        sourceId: 'feishu',
+        externalTriggerId: 'feishu:group:chat_topic_fork_1',
+      }],
+    }));
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/api/sessions/sess_parent_topic_fork') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      session: {
+        id: 'sess_parent_topic_fork',
+        sourceId: 'feishu',
+        sourceContext: { connector: 'feishu', chatId: 'chat_topic_fork_1' },
+      },
+    }));
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/api/sessions/sess_parent_topic_fork/events?filter=all') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      events: [{
+        seq: 2,
+        type: 'message',
+        role: 'user',
+        sourceContext: {
+          connector: 'feishu',
+          chatId: 'chat_topic_fork_1',
+          messageId: 'msg_topic_parent_1',
+        },
+      }],
+    }));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/api/sessions/sess_parent_topic_fork/fork') {
+    topicForkPayload = JSON.parse(body || '{}');
+    res.writeHead(201, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ session: { id: 'sess_topic_child_1' } }));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/api/sessions') {
+    topicFreshCreateCalled = true;
+    res.writeHead(201, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ session: { id: 'sess_unexpected_fresh_topic' } }));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/api/sessions/sess_topic_child_1/messages') {
+    topicForkSubmittedPayload = JSON.parse(body || '{}');
+    res.writeHead(202, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ run: { id: 'run_topic_child_1' } }));
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/api/sessions/sess_topic_child_1/responses/feishu%3Amsg_topic_child_1') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      replyPublication: {
+        state: 'ready',
+        ready: true,
+        finalRunId: 'run_topic_child_1',
+        payload: { text: 'Topic fork reply.' },
+      },
+    }));
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/api/sessions/sess_topic_child_1/events') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ events: [] }));
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+await new Promise((resolve) => topicForkServer.listen(0, '127.0.0.1', resolve));
+
+try {
+  const address = topicForkServer.address();
+  const topicSummaryForParent = {
+    tenantKey: 'tenant_topic_fork',
+    chatType: 'group',
+    chatId: 'chat_topic_fork_1',
+    messageId: 'msg_topic_child_1',
+    rootId: 'msg_topic_parent_1',
+    parentId: 'msg_topic_parent_1',
+    threadId: 'thread_topic_child_1',
+    textPreview: 'Continue this in a topic.',
+    sender: { openId: 'ou_topic_fork', tenantKey: 'tenant_topic_fork' },
+  };
+  const parentSessionId = await resolveFeishuTopicForkParentSessionId(
+    {
+      storagePaths: { messageIndexPath: topicForkIndexPath },
+    },
+    async (path, options = {}) => {
+      const response = await fetch(`http://127.0.0.1:${address.port}${path}`, {
+        method: options.method || 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        body: options.body ? JSON.stringify(options.body) : undefined,
+      });
+      const text = await response.text();
+      return { response, text, json: text ? JSON.parse(text) : null };
+    },
+    topicSummaryForParent,
+  );
+  assert.equal(parentSessionId, 'sess_parent_topic_fork');
+  const factsOnlyParentSessionId = await resolveFeishuTopicForkParentSessionId(
+    {
+      storagePaths: { messageIndexPath: join(topicForkTempDir, 'empty-index.json') },
+    },
+    async (path, options = {}) => {
+      const response = await fetch(`http://127.0.0.1:${address.port}${path}`, {
+        method: options.method || 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        body: options.body ? JSON.stringify(options.body) : undefined,
+      });
+      const text = await response.text();
+      return { response, text, json: text ? JSON.parse(text) : null };
+    },
+    topicSummaryForParent,
+  );
+  assert.equal(factsOnlyParentSessionId, 'sess_parent_topic_fork', 'topic parent lookup should fall back to session/events facts when the rebuildable index misses');
+  const botReplyParentSessionId = await resolveFeishuTopicForkParentSessionId(
+    {
+      storagePaths: { messageIndexPath: topicForkIndexPath },
+    },
+    async (path, options = {}) => {
+      const response = await fetch(`http://127.0.0.1:${address.port}${path}`, {
+        method: options.method || 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        body: options.body ? JSON.stringify(options.body) : undefined,
+      });
+      const text = await response.text();
+      return { response, text, json: text ? JSON.parse(text) : null };
+    },
+    {
+      ...topicSummaryForParent,
+      messageId: 'msg_topic_child_from_bot_reply_1',
+      rootId: 'topic_root_independent_1',
+      parentId: 'bot_reply_topic_parent_1',
+      threadId: 'thread_topic_from_bot_reply_1',
+    },
+  );
+  assert.equal(
+    botReplyParentSessionId,
+    'sess_parent_topic_fork',
+    'topic parent lookup should try parentId when rootId is an independent topic root id',
+  );
+  const handledOnlyPath = join(topicForkTempDir, 'handled-only.json');
+  await writeFile(handledOnlyPath, JSON.stringify({
+    messages: {
+      msg_topic_parent_1: {
+        status: 'sent',
+        chatId: 'chat_topic_fork_1',
+        sessionId: 'sess_parent_topic_fork',
+        responseMessageId: 'legacy_bot_reply_topic_parent_1',
+      },
+    },
+  }));
+  const handledOnlyParentSessionId = await resolveFeishuTopicForkParentSessionId(
+    {
+      storagePaths: {
+        handledMessagesPath: handledOnlyPath,
+        messageIndexPath: join(topicForkTempDir, 'handled-only-empty-index.json'),
+      },
+    },
+    async (path, options = {}) => {
+      const response = await fetch(`http://127.0.0.1:${address.port}${path}`, {
+        method: options.method || 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        body: options.body ? JSON.stringify(options.body) : undefined,
+      });
+      const text = await response.text();
+      return { response, text, json: text ? JSON.parse(text) : null };
+    },
+    {
+      ...topicSummaryForParent,
+      messageId: 'msg_topic_child_from_legacy_bot_reply_1',
+      rootId: 'legacy_bot_reply_topic_parent_1',
+      parentId: 'legacy_bot_reply_topic_parent_1',
+      threadId: 'thread_topic_from_legacy_bot_reply_1',
+    },
+  );
+  assert.equal(
+    handledOnlyParentSessionId,
+    'sess_parent_topic_fork',
+    'topic parent lookup should backfill legacy outbound bot replies from handled messages',
+  );
+
+  const reply = await generateRemoteLabReply(
+    {
+      authCookie: 'session_token=test-cookie',
+      authToken: 'ignored',
+      storagePaths: { messageIndexPath: topicForkIndexPath },
+      config: {
+        chatBaseUrl: `http://127.0.0.1:${address.port}`,
+        sessionFolder: repoRoot,
+        sessionTool: 'codex',
+        systemPrompt: 'Reply with plain text only.',
+      },
+      appClient: {},
+    },
+    topicSummaryForParent,
+  );
+
+  assert.equal(topicFreshCreateCalled, false, 'new topics with a verified parent should fork instead of fresh-create');
+  assert.equal(topicForkPayload?.externalTriggerId, 'feishu:topic:chat_topic_fork_1:thread_topic_child_1');
+  assert.equal(topicForkPayload?.sourceContext?.conversationKind, 'topic');
+  assert.equal(topicForkPayload?.sourceContext?.chatId, 'chat_topic_fork_1');
+  assert.equal(topicForkPayload?.sourceContext?.topicId, 'thread_topic_child_1');
+  assert.equal(topicForkSubmittedPayload?.sourceContext?.messageId, 'msg_topic_child_1');
+  assert.equal(reply.sessionId, 'sess_topic_child_1');
+  assert.equal(reply.replyText, 'Topic fork reply.');
+} finally {
+  await new Promise((resolve) => topicForkServer.close(resolve));
+  await rm(topicForkTempDir, { recursive: true, force: true });
 }
 
 let planningSubmittedPayload = null;

--- a/tests/test-session-forking.mjs
+++ b/tests/test-session-forking.mjs
@@ -184,6 +184,41 @@ try {
   );
   assert.equal(typeof childForkContext?.updatedAt, 'string', 'forked prepared context should keep its own timestamp');
 
+  const connectorChild = await forkSession(parent.id, {
+    name: 'Inbound Feishu topic thread',
+    group: 'Feishu',
+    description: 'Topic fork from Feishu',
+    sourceId: 'feishu',
+    sourceName: 'Feishu',
+    externalTriggerId: 'feishu:topic:chat_test:thread_test',
+    sourceContext: {
+      connector: 'feishu',
+      conversationKind: 'topic',
+      chatId: 'chat_test',
+      topicId: 'thread_test',
+    },
+  });
+  assert.ok(connectorChild, 'connector fork should create a child session');
+  assert.equal(connectorChild.forkedFromSessionId, parent.id, 'connector fork should retain parent lineage');
+  assert.equal(connectorChild.autoRenamePending, true, 'connector fork should keep normal connector auto-rename behavior');
+  assert.equal(connectorChild.group, 'Feishu', 'connector fork should accept child group override');
+  assert.equal(connectorChild.sourceId, 'feishu', 'connector fork should accept child source id override');
+  assert.equal(connectorChild.sourceName, 'Feishu', 'connector fork should accept child source name override');
+  assert.equal(connectorChild.externalTriggerId, 'feishu:topic:chat_test:thread_test', 'connector fork should bind child external trigger id');
+  assert.equal(connectorChild.sourceContext?.conversationKind, 'topic', 'connector fork should bind child source context');
+  const reusedConnectorChild = await forkSession(parent.id, {
+    externalTriggerId: 'feishu:topic:chat_test:thread_test',
+    sourceContext: {
+      connector: 'feishu',
+      conversationKind: 'topic',
+      chatId: 'chat_test',
+      topicId: 'thread_test',
+    },
+  });
+  assert.equal(reusedConnectorChild?.id, connectorChild.id, 'connector fork should reuse an existing external trigger child');
+  const reusedHistory = await getHistory(reusedConnectorChild.id);
+  assert.equal(reusedHistory.length, parentHistory.length, 'reusing a connector fork should not append duplicate copied history');
+
   const promptParent = await createSession(workspace, 'missing-tool', 'Prompt cache parent', {
     group: 'Painting',
     description: 'Prepared context prompt reuse',


### PR DESCRIPTION
## Summary
- add connector topic fork session flow for Feishu topic/thread messages
- record Feishu inbound and outbound message-to-session indexes for parent lookup
- sanitize Codex/Claude CLI spawn arguments to strip NUL bytes from prompt history

## Verification
- `node tests/test-feishu-connector.mjs`
- `node tests/test-session-forking.mjs`
- `node tests/test-codex-prompt-sanitization.mjs`
- `node --check scripts/feishu-connector.mjs`
- `node --check lib/connector-message-index.mjs`
- `node --check chat/adapters/codex.mjs`
- `node --check chat/adapters/claude.mjs`
- `node --check chat/spawn-arg-sanitizer.mjs`